### PR TITLE
Fix a few issues with "Supported features" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ added to currently opened file after confirming.
 - Entire file import
   - `import './foo.js'`
 - Alias imports
-  - `import Foo as Bar from './foo.js'`
-- Asterisk imports
+  - `import { Foo as Bar } from './foo.js'`
+- Namespace imports
   - `import * as Foo from './foo.js'`
 
 ## Contribute


### PR DESCRIPTION
- Aliased imports only apply to named imports and require the curly braces.
- "Asterisk imports" are actually called "namespace imports"
