### PR TITLE
remove extra space after default-only import

### DIFF
--- a/lib/imports/ImportOrganiser.js
+++ b/lib/imports/ImportOrganiser.js
@@ -52,7 +52,7 @@ export default class ImportOrganiser {
               const defaultSpecifiers = _.filter(singleImport.specifiers, (specifier) => specifier.def);
               const namedSpecifiers = _.filter(singleImport.specifiers, (specifier) => !specifier.def);
               const leftBracketWithComma = defaultSpecifiers.length === 1 ? `, {${spaceForNamedImports}` : `{${spaceForNamedImports}`;
-              const leftBracket = namedSpecifiers.length > 0 ? leftBracketWithComma : spaceForNamedImports;
+              const leftBracket = namedSpecifiers.length > 0 ? leftBracketWithComma : '';
               const rightBracket = namedSpecifiers.length > 0 ? `${spaceForNamedImports}}` : '';
               const defaultSpecifier = defaultSpecifiers.length === 1 ? defaultSpecifiers[0] : '';
               const trailingSemicolon = atom.config.get('js-autoimport.trailingSemicolon') ? ';' : '';


### PR DESCRIPTION
the case when namedSpecifiers.length === 0 it will become:

```
import ${renderSpecifier(defaultSpecifier)}${''}${''}${''} from '${singleImport.file}'${trailingSemicolon}`
```
